### PR TITLE
Account for scale factor in progress overlay

### DIFF
--- a/Lifestream/GUI/ProgressOverlay.cs
+++ b/Lifestream/GUI/ProgressOverlay.cs
@@ -18,7 +18,7 @@ namespace Lifestream.GUI
         {
             this.SizeConstraints = new()
             {
-                MinimumSize = new(ImGuiHelpers.MainViewport.Size.X, 0),
+                MinimumSize = new(ImGuiHelpers.MainViewport.Size.X / ImGuiHelpers.GlobalScale, 0),
                 MaximumSize = new(0, float.MaxValue)
             };
         }


### PR DESCRIPTION
Progress overlay overflows offscreen on my 4K main display. I don't know if GlobalScale is checking the windows scale factor or something in the Dalamud settings or what, but this fixes it