### PR TITLE
Island shortcut

### DIFF
--- a/Lifestream/Lang.cs
+++ b/Lifestream/Lang.cs
@@ -77,6 +77,8 @@ internal static class Lang
     //12	TEXT_AETHERYTE_MOVE_INSTANCE	<Gui(69)/> Changer d'instance
     public static readonly string[] TravelToInstancedArea = ["Travel to Instanced Area.", "インスタンスエリアへ移動", "In ein instanziiertes Areal wechseln", "Changer d'instance", "切换副本区", "切換副本區"];
     public static string ToReduceCongestion => Svc.Data.GetExcelSheet<Addon>().GetRow(2090).Text.ExtractText();
+    public static string[] TravelToYourIsland = ["Travel to your island?", "あなたの島へ向かいますか？", "Zu deiner Insel fahren?", "Voulez-vous aller sur votre île?"]; // row 4
+    public static string[] TravelToMyIsland = ["Travel to my island.", "「自分の島」に行く", "Zur eigenen Insel fahren", "Aller sur son île"]; // row 7
     public static readonly string[] Entrance =
     [
         "ハウスへ入る",

--- a/Lifestream/Lifestream.cs
+++ b/Lifestream/Lifestream.cs
@@ -264,7 +264,7 @@ public unsafe class Lifestream : IDalamudPlugin
                 TaskMBShortcut.Enqueue();
             }
         }
-        else if (arguments.EqualsIgnoreCaseAny("island", "is", "sanctuary"))
+        else if (arguments.EqualsIgnoreCaseAny("island", "is", "sanctuary") || arguments.StartsWithAny("island ", "is ", "sanctuary "))
         {
             var arglist = arguments.Split(" ");
             if (arglist.Length == 1)
@@ -274,6 +274,8 @@ public unsafe class Lifestream : IDalamudPlugin
                 var name = arglist[1];
                 if (DataStore.IslandNPCs.TryGetFirst(x => x.Value.Any(y => y.Contains(name, StringComparison.OrdinalIgnoreCase)), out var npc))
                     TaskISShortcut.Enqueue(npc.Key);
+                else
+                    DuoLog.Error($"Could not parse input: {name}");
             }
         }
         else if(Utils.TryParseAddressBookEntry(arguments, out var entry))

--- a/Lifestream/Lifestream.cs
+++ b/Lifestream/Lifestream.cs
@@ -264,6 +264,18 @@ public unsafe class Lifestream : IDalamudPlugin
                 TaskMBShortcut.Enqueue();
             }
         }
+        else if (arguments.EqualsIgnoreCaseAny("island", "is", "sanctuary"))
+        {
+            var arglist = arguments.Split(" ");
+            if (arglist.Length == 1)
+                TaskISShortcut.Enqueue();
+            else
+            {
+                var name = arglist[1];
+                if (DataStore.IslandNPCs.TryGetFirst(x => x.Value.Contains(name, StringComparison.OrdinalIgnoreCase), out var npc))
+                    TaskISShortcut.Enqueue(npc.Key);
+            }
+        }
         else if(Utils.TryParseAddressBookEntry(arguments, out var entry))
         {
             ChatPrinter.Green($"[Lifestream] Address parsed: {entry.GetAddressString()}");

--- a/Lifestream/Lifestream.cs
+++ b/Lifestream/Lifestream.cs
@@ -272,7 +272,7 @@ public unsafe class Lifestream : IDalamudPlugin
             else
             {
                 var name = arglist[1];
-                if (DataStore.IslandNPCs.TryGetFirst(x => x.Value.Contains(name, StringComparison.OrdinalIgnoreCase), out var npc))
+                if (DataStore.IslandNPCs.TryGetFirst(x => x.Value.Any(y => y.Contains(name, StringComparison.OrdinalIgnoreCase)), out var npc))
                     TaskISShortcut.Enqueue(npc.Key);
             }
         }

--- a/Lifestream/Systems/Legacy/DataStore.cs
+++ b/Lifestream/Systems/Legacy/DataStore.cs
@@ -17,7 +17,7 @@ internal class DataStore
     internal Dictionary<TinyAetheryte, List<TinyAetheryte>> Aetherytes = [];
     internal string[] Worlds = Array.Empty<string>();
     internal string[] DCWorlds = Array.Empty<string>();
-    internal Dictionary<TaskISShortcut.IslandNPC, string> IslandNPCs = [];
+    internal Dictionary<TaskISShortcut.IslandNPC, string[]> IslandNPCs = [];
     internal StaticData StaticData;
 
     internal TinyAetheryte GetMaster(TinyAetheryte aetheryte)
@@ -67,7 +67,10 @@ internal class DataStore
         }
 
         foreach (TaskISShortcut.IslandNPC npc in Enum.GetValues(typeof(TaskISShortcut.IslandNPC)))
-            IslandNPCs.Add(npc, Svc.Data.GetExcelSheet<ENpcResident>().GetRow((uint)npc).Singular);
+        {
+            var row = Svc.Data.GetExcelSheet<ENpcResident>().GetRow((uint)npc);
+            IslandNPCs.Add(npc, [row.Singular, row.Title]);
+        }
     }
 
     internal uint GetAetheryteSortOrder(uint id)

--- a/Lifestream/Systems/Legacy/DataStore.cs
+++ b/Lifestream/Systems/Legacy/DataStore.cs
@@ -3,6 +3,7 @@ using ECommons.Events;
 using ECommons.ExcelServices;
 using ECommons.GameHelpers;
 using Lifestream.Data;
+using Lifestream.Tasks.Shortcuts;
 using Lumina.Excel.GeneratedSheets;
 using System.IO;
 using Path = System.IO.Path;
@@ -16,6 +17,7 @@ internal class DataStore
     internal Dictionary<TinyAetheryte, List<TinyAetheryte>> Aetherytes = [];
     internal string[] Worlds = Array.Empty<string>();
     internal string[] DCWorlds = Array.Empty<string>();
+    internal Dictionary<TaskISShortcut.IslandNPC, string> IslandNPCs = [];
     internal StaticData StaticData;
 
     internal TinyAetheryte GetMaster(TinyAetheryte aetheryte)
@@ -63,6 +65,9 @@ internal class DataStore
         {
             BuildWorlds();
         }
+
+        foreach (TaskISShortcut.IslandNPC npc in Enum.GetValues(typeof(TaskISShortcut.IslandNPC)))
+            IslandNPCs.Add(npc, Svc.Data.GetExcelSheet<ENpcResident>().GetRow((uint)npc).Singular);
     }
 
     internal uint GetAetheryteSortOrder(uint id)

--- a/Lifestream/Tasks/Shortcuts/TaskISShortcut.cs
+++ b/Lifestream/Tasks/Shortcuts/TaskISShortcut.cs
@@ -1,0 +1,182 @@
+﻿using ECommons.GameFunctions;
+using ECommons.GameHelpers;
+using ECommons.Throttlers;
+using ECommons.UIHelpers.AddonMasterImplementations;
+using FFXIVClientStructs.FFXIV.Client.Game.Control;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using Lifestream.Tasks.SameWorld;
+using Lifestream.Tasks.Utility;
+
+namespace Lifestream.Tasks.Shortcuts;
+public static unsafe class TaskISShortcut
+{
+    public enum IslandNPC : uint
+    {
+        Baldin = 1043621,
+        TactfulTaskmaster = 1043078,
+        ExcitableExplorer = 1043081,
+        EnterprisingExporter = 1043464,
+        HorrendousHoarder = 1043463,
+        FelicitousFurball = 1043473,
+        CreatureComforter = 1043466,
+        ProduceProducer = 1043465,
+    }
+
+    public static class IslandTerritories
+    {
+        public const uint Moraby = 135;
+        public const uint Island = 1055;
+    }
+
+    public static readonly Dictionary<IslandNPC, Vector3> NPCPoints = new()
+    {
+        [IslandNPC.Baldin] = new(173.05f, 14.10f, 668.42f),
+        [IslandNPC.TactfulTaskmaster] = new(-278.37f, 40.00f, 229.82f),
+        [IslandNPC.ExcitableExplorer] = new(-265.44f, 40.00f, 234.52f),
+        [IslandNPC.EnterprisingExporter] = new(-265.72f, 41.01f, 210.44f),
+        [IslandNPC.HorrendousHoarder] = new(-265.72f, 41.01f, 210.44f),
+        [IslandNPC.FelicitousFurball] = new(-272.06f, 41.00f, 212.32f),
+        [IslandNPC.CreatureComforter] = new(-268.60f, 55.20f, 134.44f),
+        [IslandNPC.ProduceProducer] = new(-258.16f, 55.20f, 135.01f),
+    };
+
+    public static void Enqueue(IslandNPC? npcNullable = null, bool returnHome = true)
+    {
+        if (P.TaskManager.IsBusy)
+        {
+            DuoLog.Error($"Lifestream is busy, could not process request");
+            return;
+        }
+        if (!Player.Available)
+        {
+            DuoLog.Error("Player not available");
+            return;
+        }
+        if (returnHome)
+        {
+            if (!Player.IsInHomeWorld)
+            {
+                P.TPAndChangeWorld(Player.HomeWorld, !Player.IsInHomeDC, null, true, null, false, false);
+            }
+            P.TaskManager.Enqueue(() => Player.Interactable && Player.IsInHomeWorld && IsScreenReady());
+        }
+        var point = npcNullable == null ? NPCPoints[IslandNPC.TactfulTaskmaster] : NPCPoints[npcNullable.Value];
+        P.TaskManager.Enqueue(() =>
+        {
+            if (Player.Territory == IslandTerritories.Island)
+            {
+                P.TaskManager.Enqueue(P.VnavmeshManager.IsReady);
+                var task = P.VnavmeshManager.Pathfind(Player.Position, point, false);
+                P.TaskManager.Enqueue(() =>
+                {
+                    if (!task.IsCompleted) return false;
+                    var path = task.Result;
+                    P.TaskManager.Enqueue(TaskMoveToHouse.UseSprint);
+                    P.TaskManager.Enqueue(() => P.FollowPath.Move([.. path], true));
+                    return true;
+                }, "Build path and check");
+            }
+            else if (Player.Territory == IslandTerritories.Moraby)
+                TravelToIsland();
+            else
+                EnqueueFromStart();
+        });
+
+        void EnqueueFromStart()
+        {
+            if (Player.Territory != IslandTerritories.Moraby)
+            {
+                TaskTpAndWaitForArrival.Enqueue(10);
+                P.TaskManager.Enqueue(() => Svc.Condition[ConditionFlag.BetweenAreas] || Svc.Condition[ConditionFlag.BetweenAreas51], "WaitUntilBetweenAreas");
+                P.TaskManager.Enqueue(() => Player.Interactable && IsScreenReady() && Player.Territory == IslandTerritories.Moraby, "WaitUntilPlayerInteractableInMoraby", TaskSettings.Timeout2M);
+            }
+            TravelToIsland();
+        }
+
+        void TravelToIsland()
+        {
+            P.TaskManager.Enqueue(EnqueueBaldinNavigation);
+            P.TaskManager.Enqueue(InteractWithBaldin);
+            P.TaskManager.Enqueue(SelectStringIsland);
+            P.TaskManager.Enqueue(ConfirmIslandTravel);
+            P.TaskManager.Enqueue(() => Player.Interactable && IsScreenReady() && Player.Territory == IslandTerritories.Island, "WaitUntilPlayerInteractableOnIsland", TaskSettings.Timeout2M);
+        }
+
+        bool EnqueueBaldinNavigation()
+        {
+            P.TaskManager.Enqueue(Utils.WaitForScreen);
+            P.TaskManager.Enqueue(P.VnavmeshManager.IsReady);
+            P.TaskManager.Enqueue(() =>
+            {
+                var task = P.VnavmeshManager.Pathfind(Player.Position, NPCPoints[IslandNPC.Baldin], false);
+                P.TaskManager.Enqueue(() =>
+                {
+                    if (!task.IsCompleted) return false;
+                    var path = task.Result;
+                    P.TaskManager.Enqueue(TaskMoveToHouse.UseSprint);
+                    P.TaskManager.Enqueue(() => P.FollowPath.Move([.. path], true));
+                    return true;
+                }, "Build path and check");
+            }, "Master navmesh task");
+            return Vector3.Distance(Player.Position, NPCPoints[IslandNPC.Baldin]) < 3f;
+        }
+
+        bool InteractWithBaldin()
+        {
+            if (Svc.Condition[ConditionFlag.OccupiedInQuestEvent]) return true;
+            var baldin = Svc.Objects.FirstOrDefault(x => x.DataId == (uint)IslandNPC.Baldin);
+            if (Vector3.Distance(Player.Position, baldin.Position) < 3f) return false;
+            if (baldin.IsTarget())
+            {
+                if (EzThrottler.Throttle(nameof(InteractWithBaldin)))
+                {
+                    TargetSystem.Instance()->InteractWithObject(baldin.Struct(), false);
+                    return false;
+                }
+            }
+            else
+            {
+                if (EzThrottler.Throttle("BaldinSetTarget"))
+                {
+                    Svc.Targets.Target = baldin;
+                    return false;
+                }
+            }
+            return false;
+        }
+
+        bool SelectStringIsland() => Utils.TrySelectSpecificEntry(Lang.TravelToMyIsland, () => EzThrottler.Throttle(nameof(SelectStringIsland)));
+
+        bool ConfirmIslandTravel()
+        {
+            var addon = (AddonSelectYesno*)Utils.GetSpecificYesno(true, Lang.TravelToYourIsland);
+            if (addon != null && addon->YesButton->IsEnabled)
+            {
+                if (EzThrottler.Throttle(nameof(ConfirmIslandTravel), 5000))
+                {
+                    new AddonMaster.SelectYesno(addon).Yes();
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    internal static void EnqueueNavToNPC(Vector3 npc)
+    {
+        P.TaskManager.Enqueue(Utils.WaitForScreen);
+        P.TaskManager.Enqueue(P.VnavmeshManager.IsReady);
+        P.TaskManager.Enqueue(() =>
+        {
+            var task = P.VnavmeshManager.Pathfind(Player.Position, npc, false);
+            P.TaskManager.Enqueue(() =>
+            {
+                if (!task.IsCompleted) return false;
+                var path = task.Result;
+                P.TaskManager.Enqueue(TaskMoveToHouse.UseSprint);
+                P.TaskManager.Enqueue(() => P.FollowPath.Move([.. path], true));
+                return true;
+            }, "Build path and check");
+        }, "Master navmesh task");
+    }
+}

--- a/Lifestream/Tasks/Shortcuts/TaskISShortcut.cs
+++ b/Lifestream/Tasks/Shortcuts/TaskISShortcut.cs
@@ -4,7 +4,7 @@ using ECommons.Throttlers;
 using ECommons.UIHelpers.AddonMasterImplementations;
 using FFXIVClientStructs.FFXIV.Client.Game.Control;
 using FFXIVClientStructs.FFXIV.Client.UI;
-using FFXIVClientStructs.FFXIV.Component.GUI;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using Lifestream.Tasks.SameWorld;
 using Lifestream.Tasks.Utility;
 
@@ -65,9 +65,7 @@ public static unsafe class TaskISShortcut
         P.TaskManager.Enqueue(() =>
         {
             if (Player.Territory == IslandTerritories.Island)
-            {
                 EnqueueNavToNPC(point);
-            }
             else if (Player.Territory == IslandTerritories.Moraby)
                 TravelToIsland();
             else
@@ -97,7 +95,7 @@ public static unsafe class TaskISShortcut
 
         bool EnqueueBaldinNavigation()
         {
-            if (!P.VnavmeshManager.IsReady() ?? false || P.VnavmeshManager.PathfindInProgress() || P.VnavmeshManager.IsRunning()) return false;
+            if (P.VnavmeshManager.PathfindInProgress() || P.VnavmeshManager.IsRunning() || AgentMap.Instance()->IsPlayerMoving == 1) return false;
             P.VnavmeshManager.PathfindAndMoveTo(NPCPoints[IslandNPC.Baldin], false);
             return Vector3.Distance(Player.Position, NPCPoints[IslandNPC.Baldin]) < 3f && !P.VnavmeshManager.IsRunning();
         }


### PR DESCRIPTION
takes in npc names or their titles as extra params for the end location. Defaults to the workshop npc.

I put in the return home param but I'm not sure if it's even needed. You could technically just want to go to the island on another world (not your own) but the use case is incredibly niche