### PR TITLE
Implement PaissaDB Export Logic

### DIFF
--- a/Lifestream/GUI/TabUtility.cs
+++ b/Lifestream/GUI/TabUtility.cs
@@ -1,12 +1,7 @@
 ﻿using ECommons.GameHelpers;
-using NightmareUI;
+using Lifestream.Paissa;
 using NightmareUI.ImGuiElements;
 using NightmareUI.PrimaryUI;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Lifestream.GUI;
 public static class TabUtility
@@ -18,6 +13,7 @@ public static class TabUtility
         EmptyName = "Disabled",
         ShouldHideWorld = (x) => x == Player.Object?.CurrentWorld.RowId
     };
+    static PaissaImporter PaissaImporter = new();
 
     public static void Draw()
     {
@@ -27,6 +23,11 @@ public static class TabUtility
             {
                 ImGuiEx.SetNextItemFullWidth();
                 WorldSelector.Draw(ref TargetWorldID);
+            })
+            .Section("Import house listings from PaissaDB")
+            .Widget(() => {
+                ImGuiEx.SetNextItemFullWidth();
+                PaissaImporter.Draw();
             })
             .Draw();
     }

--- a/Lifestream/Paissa/PaissaData.cs
+++ b/Lifestream/Paissa/PaissaData.cs
@@ -61,3 +61,8 @@ public class PaissaPlot
     [JsonProperty("lotto_phase_until")]
     public float LottoPhaseUntil;
 }
+
+public enum PaissaStatus
+{
+    Idle, Progress, Success, Error
+}

--- a/Lifestream/Paissa/PaissaData.cs
+++ b/Lifestream/Paissa/PaissaData.cs
@@ -1,0 +1,63 @@
+﻿using Newtonsoft.Json;
+
+namespace Lifestream.Paissa;
+
+public class PaissaResponse
+{
+    [JsonProperty("id")]
+    public int Id;
+    [JsonProperty("name")]
+    public string Name;
+    [JsonProperty("districts")]
+    public List<PaissaDistrict> Districts;
+    [JsonProperty("num_open_plots")]
+    public int NumOpenPlots;
+    [JsonProperty("oldest_plot_time")]
+    public float OldestPlotTime;
+}
+
+public class PaissaDistrict
+{
+    [JsonProperty("id")]
+    public int Id;
+    [JsonProperty("name")]
+    public string Name;
+    [JsonProperty("num_open_plots")]
+    public int NumOpenPlots;
+    [JsonProperty("oldest_plot_time")]
+    public float OldestPlotTime;
+    [JsonProperty("open_plots")]
+    public List<PaissaPlot> OpenPlots;
+}
+
+public class PaissaPlot
+{
+    [JsonProperty("world_id")]
+    public int WorldId;
+    [JsonProperty("district_id")]
+    public int DistrictId;
+    [JsonProperty("ward_number")]
+    public int WardNumber;
+    [JsonProperty("plot_number")]
+    public int PlotNumber;
+    [JsonProperty("size")]
+    public int Size;
+    [JsonProperty("price")]
+    public int Price;
+    [JsonProperty("last_updated_time")]
+    public float LastUpdatedTime;
+    [JsonProperty("first_seen_time")]
+    public float FirstSeenTime;
+    [JsonProperty("est_time_open_min")]
+    public float ESTTimeOpenMin;
+    [JsonProperty("est_time_open_max")]
+    public float ESTTimeOpenMax;
+    [JsonProperty("purchase_system")]
+    public int PurchaseSystem;
+    [JsonProperty("lotto_entries")]
+    public int LottoEntries;
+    [JsonProperty("lotto_phase")]
+    public int LottoPhase;
+    [JsonProperty("lotto_phase_until")]
+    public float LottoPhaseUntil;
+}

--- a/Lifestream/Paissa/PaissaImporter.cs
+++ b/Lifestream/Paissa/PaissaImporter.cs
@@ -1,0 +1,57 @@
+﻿using ECommons.Configuration;
+using ECommons.GameHelpers;
+using Lifestream.Data;
+
+namespace Lifestream.Paissa
+{
+    public class PaissaImporter
+    {
+        private static PaissaImporter? _instance;
+        public static PaissaImporter Instance {
+            get
+            {
+                _instance ??= new();
+                return _instance;
+            }
+        }
+
+        private string ID;
+        private string folderText = "No folder yet...";
+
+        public PaissaImporter(string id = "##paissa")
+        {
+            ID = id;
+        }
+
+        public void Draw()
+        {
+            ImGui.PushID(ID);
+
+            if (ImGui.Button("Import from PaissaDB"))
+            {
+                PluginLog.Debug("Retrieving house listings from PaissaDB...");
+
+                Task.Run(async () => {
+                    var responseData = await PaissaUtils.GetListingsAsync((int)Player.HomeWorldId);
+                    PaissaResponse responseObject = EzConfig.DefaultSerializationFactory.Deserialize<PaissaResponse>(responseData);
+                    AddressBookFolder newFolder = PaissaUtils.GetAddressBookFolderFromPaissaResponse(responseObject);
+
+                    /* 
+
+                    ADD NEW FOLDER TO LIST HERE
+
+                    */
+
+                    folderText = EzConfig.DefaultSerializationFactory.Serialize(newFolder, false);
+                });
+            }
+
+            // Display folder object in text field to copy and import for testing
+            byte[] textBuffer = new byte[2048];
+            Encoding.UTF8.GetBytes(folderText, 0, folderText.Length, textBuffer, 0);
+            ImGui.InputText("", textBuffer, (uint)textBuffer.Length);
+
+            ImGui.PopID();
+        }
+    }
+}

--- a/Lifestream/Paissa/PaissaUtils.cs
+++ b/Lifestream/Paissa/PaissaUtils.cs
@@ -40,7 +40,7 @@ public class PaissaUtils
         return folder;
     }
 
-    public static async Task<string> GetListingsAsync(int worldId)
+    public static async Task<string> GetListingsForHomeWorldAsync(int worldId)
     {
         string url = $"https://paissadb.zhu.codes/worlds/{worldId}";
 
@@ -48,23 +48,29 @@ public class PaissaUtils
         {
             try
             {
+                PluginLog.Debug($"Getting PaissaDB listings for World ID {worldId}...");
                 HttpResponseMessage response = await client.GetAsync(url);
 
                 if (response.IsSuccessStatusCode)
                 {
                     string responseData = await response.Content.ReadAsStringAsync();
-                    PluginLog.Debug("Response data:");
+                    PluginLog.Debug("Response received successfully from PaissaDB:");
                     PluginLog.Debug(responseData);
                     return responseData;
+                }
+                else
+                {
+                    string errorMessage = $"Error: {response.StatusCode} - {response.ReasonPhrase}";
+                    PluginLog.Error(errorMessage);
+                    return errorMessage;
                 }
             }
             catch (Exception ex)
             {
                 PluginLog.Error($"Exception occurred when getting house listings from PaissaDB: {ex.Message}");
+                return $"Exception: {ex.Message}";
             }
         }
-
-        return "Error getting house listings from PaissaDB";
     }
 
     private static string GetSizeString(int size)

--- a/Lifestream/Paissa/PaissaUtils.cs
+++ b/Lifestream/Paissa/PaissaUtils.cs
@@ -1,4 +1,5 @@
 ﻿using Lifestream.Data;
+using System.Drawing.Configuration;
 using System.Net.Http;
 
 namespace Lifestream.Paissa;
@@ -73,10 +74,36 @@ public class PaissaUtils
         }
     }
 
+    public static string GetStatusStringFromStatus(PaissaStatus status)
+    {
+        return status switch
+        {
+            PaissaStatus.Idle       => "",
+            PaissaStatus.Progress   => "Retrieving...",
+            PaissaStatus.Success    => "Success!",
+            PaissaStatus.Error      => "Error!",
+            _                       => "",
+        };
+    }
+
+    public static Vector4 GetStatusColorFromStatus(PaissaStatus status)
+    {
+        return status switch {
+            PaissaStatus.Idle       => System.Drawing.KnownColor.White.Vector(),
+            PaissaStatus.Progress   => System.Drawing.KnownColor.White.Vector(),
+            PaissaStatus.Success    => System.Drawing.KnownColor.LimeGreen.Vector(),
+            PaissaStatus.Error      => System.Drawing.KnownColor.Red.Vector(),
+            _                       => System.Drawing.KnownColor.White.Vector()
+        };
+    }
+
     private static string GetSizeString(int size)
     {
-        if (size == 0) return "Small";
-        else if (size == 1) return "Medium";
-        else return "Large";
+        return size switch
+        {
+            0 => "Small",
+            1 => "Medium",
+            _ => "Large"
+        };
     }
 }

--- a/Lifestream/Paissa/PaissaUtils.cs
+++ b/Lifestream/Paissa/PaissaUtils.cs
@@ -1,0 +1,76 @@
+﻿using Lifestream.Data;
+using System.Net.Http;
+
+namespace Lifestream.Paissa;
+
+public class PaissaUtils
+{
+    public static AddressBookFolder GetAddressBookFolderFromPaissaResponse(PaissaResponse paissaData)
+    {
+        List<AddressBookEntry> entries = [];
+
+        foreach (var district in paissaData.Districts)
+        {
+            foreach (var plot in district.OpenPlots)
+            {
+                // Increment numbers by 1 because PaissaDB has them 0-indexed
+                var wardStr = (plot.WardNumber + 1).ToString();
+                var plotStr = (plot.PlotNumber + 1).ToString();
+                var entry = Utils.BuildAddressBookEntry
+                (
+                    paissaData.Name,
+                    district.Name,
+                    wardStr,
+                    plotStr,
+                    false,
+                    false,
+                    $"{district.Name} Ward {wardStr} Plot {plotStr} ({GetSizeString(plot.Size)})"
+                );
+                entries.Add(entry);
+            }
+        }
+
+        AddressBookFolder folder = new() {
+            ExportedName = "House Listings",
+            Entries = entries,
+            IsDefault = false,
+            GUID = Guid.NewGuid()
+        };
+
+        return folder;
+    }
+
+    public static async Task<string> GetListingsAsync(int worldId)
+    {
+        string url = $"https://paissadb.zhu.codes/worlds/{worldId}";
+
+        using (HttpClient client = new HttpClient())
+        {
+            try
+            {
+                HttpResponseMessage response = await client.GetAsync(url);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    string responseData = await response.Content.ReadAsStringAsync();
+                    PluginLog.Debug("Response data:");
+                    PluginLog.Debug(responseData);
+                    return responseData;
+                }
+            }
+            catch (Exception ex)
+            {
+                PluginLog.Error($"Exception occurred when getting house listings from PaissaDB: {ex.Message}");
+            }
+        }
+
+        return "Error getting house listings from PaissaDB";
+    }
+
+    private static string GetSizeString(int size)
+    {
+        if (size == 0) return "Small";
+        else if (size == 1) return "Medium";
+        else return "Large";
+    }
+}

--- a/Lifestream/Utils.cs
+++ b/Lifestream/Utils.cs
@@ -574,7 +574,7 @@ internal static unsafe class Utils
             .Replace("%numeric", "([0-9]{1,2})");
     }
 
-    public static AddressBookEntry BuildAddressBookEntry(string worldStr, string cityStr, string wardNum, string plotApartmentNum, bool isApartment, bool isSubdivision)
+    public static AddressBookEntry BuildAddressBookEntry(string worldStr, string cityStr, string wardNum, string plotApartmentNum, bool isApartment, bool isSubdivision, string name = null)
     {
         var world = ExcelWorldHelper.Get(worldStr, true);
         if(world == null)
@@ -603,6 +603,7 @@ internal static unsafe class Utils
                 Plot = plot,
                 ApartmentSubdivision = isSubdivision,
             };
+            if (name != null) entry.Name = name;
             return entry;
         }
         return null;


### PR DESCRIPTION
This PR adds [PaissaDB](https://zhu.codes/paissa) export functionality to the Utility tab of Lifestream, allowing for the export of available house listings on the player's home world from PaissaDB.

Three new files have been added under the namespace `Lifestream.Paissa`:
- `PaissaData.cs` - several classes containing data structures for various Paissa objects
- `PaissaUtils.cs` - several useful utility methods for Paissa
- `PaissaImporter.cs` - the static class object to be loaded and drawn in `TabUtility.cs`

Two existing file modifications have been made:
- `TabUtility.cs` - the `PaissaImporter` object has been instantiated and drawn as a section and widget below `WorldSelector`
- `Utils.cs` - a default parameter has been added to `BuildAddressBookEntry` which allows passing in an optional `name` parameter

I've got plenty of ideas for various ways to expand on the feature, hopefully with your help:
- Automatically import the created `AddressBookFolder` into Lifestream (maybe have a setting to enable/disable this?)
- Table displaying each house listing and information about it (price, current number of bids, etc.) along with buttons to import an individual entry instead of everything
- Filters to only return house listings that you are looking for (specific districts, plots, sizes, etc.)
- Automatic periodic queries to get updated number of bids (setting to enable/disable, disabled by default)
- Prevent import button from being spam clicked to prevent overloading PaissaDB API

![1735423773_ffxiv_dx11_17-09-33](https://github.com/user-attachments/assets/75d786cd-838f-4c5a-aeb9-72c578b0c46a)
