### PR TITLE
Add wotsit integration for teleporting to aethernet

### DIFF
--- a/Lifestream/Data/Config.cs
+++ b/Lifestream/Data/Config.cs
@@ -77,4 +77,5 @@ public class Config : IEzConfig
     public bool TerminateSelfPartyFinder = false;
     public Dictionary<ulong, string> CharaMap = [];
     public bool UseMount = true;
+    public bool WotsitIntegrationEnabled = true;
 }

--- a/Lifestream/GUI/UISettings.cs
+++ b/Lifestream/GUI/UISettings.cs
@@ -151,6 +151,16 @@ internal static unsafe class UISettings
         .Checkbox("Enable Data center and World visit from Character Select Menu", () => ref P.Config.AllowDCTravelFromCharaSelect)
         .Checkbox("Use world visit instead of DC visit to travel to same world on guest DC", () => ref P.Config.UseGuestWorldTravel)
 
+        .Section("Wotsit Integration")
+        .Widget(() =>
+        {
+            if (ImGui.Checkbox("Enable Wotsit Integration for teleporting to Aethernet destinations", ref P.Config.WotsitIntegrationEnabled))
+            {
+                P.WotsitManager.TryClearWotsit();
+                P.WotsitManager.MaybeTryInit();
+            }
+        })
+
         .Draw();
     }
 

--- a/Lifestream/IPC/WotsitManager.cs
+++ b/Lifestream/IPC/WotsitManager.cs
@@ -1,0 +1,158 @@
+using Dalamud.Plugin.Ipc;
+using Dalamud.Utility;
+using Lifestream.Tasks.SameWorld;
+using Lumina.Excel.Sheets;
+
+namespace Lifestream.IPC;
+
+public class WotsitManager : IDisposable
+{
+    // Map from registered Guid string to (aetheryte ID, aethernet ID).
+    private readonly Dictionary<string, (uint, uint)> _registered = new();
+
+    private readonly ICallGateSubscriber<bool> _faAvailable;
+    private readonly ICallGateSubscriber<string, bool> _faInvoke;
+    private ICallGateSubscriber<string, string, string, uint, string>? _faRegisterWithSearch;
+
+    private static readonly Dictionary<uint, uint> AetheryteToTownPlaceName = new()
+    {
+        { 2, 39 },     // Gridania
+        { 8, 27 },     // Limsa Lominsa
+        { 9, 51 },     // Ul'dah
+        { 62, 1484 },  // The Gold Saucer
+        { 70, 62 },    // Ishgard
+        { 75, 2082 },  // Idyllshire
+        { 104, 2403 }, // Rhalgr's Reach
+        { 111, 513 },  // Kugane
+        { 127, 2507 }, // The Doman Enclave
+        { 133, 516 },  // The Crystarium
+        { 134, 517 },  // Eulmore
+        { 182, 3706 }, // Old Sharlayan
+        { 183, 3707 }, // Radz-at-Han
+        { 216, 4504 }, // Tuliyollal
+        { 217, 4503 }, // Solution Nine
+    };
+
+    // Any invisible aethernet shards that should be added to wotsit. In the
+    // future this should be replaced with a config option.
+    private static readonly List<uint> InvisibleWhitelist = [
+        91,  // Prologue Gate (Western Hinterlands)
+        92,  // Epilogue Gate (Eastern Hinterlands)
+        120, // The Ruby Price
+    ];
+
+    public WotsitManager()
+    {
+        _faAvailable = Svc.PluginInterface.GetIpcSubscriber<bool>("FA.Available");
+        _faAvailable.Subscribe(MaybeTryInit);
+        _faInvoke = Svc.PluginInterface.GetIpcSubscriber<string, bool>("FA.Invoke");
+        _faInvoke.Subscribe(HandleInvoke);
+        MaybeTryInit();
+    }
+
+    public void Dispose()
+    {
+        ClearWotsit();
+        _faAvailable?.Unsubscribe(MaybeTryInit);
+        _faInvoke?.Unsubscribe(HandleInvoke);
+        GC.SuppressFinalize(this);
+    }
+
+    private void HandleInvoke(string id)
+    {
+        if (!_registered.TryGetValue(id, out var value))
+        {
+            return;
+        }
+        var (aetheryteId, aethernetId) = value;
+        PluginLog.Debug($"WotsitManager: Received FA.Invoke(\"{id}\") => ({aetheryteId}, {aethernetId})");
+        try
+        {
+            TaskAetheryteAethernetTeleport.Enqueue(aetheryteId, aethernetId);
+        }
+        catch (Exception e)
+        {
+            DuoLog.Error($"Could not teleport to aethernet ({aetheryteId}, {aethernetId}): {e}");
+        }
+    }
+
+    public void TryClearWotsit()
+    {
+        try
+        {
+            ClearWotsit();
+        }
+        catch (Exception e)
+        {
+            PluginLog.Warning($"WotsitManager: Failed to clear wotsit: {e}");
+        }
+    }
+
+    private void ClearWotsit()
+    {
+        var faUnregisterAll = Svc.PluginInterface.GetIpcSubscriber<string, bool>("FA.UnregisterAll");
+        faUnregisterAll!.InvokeFunc(P.Name);
+        PluginLog.Debug($"WotsitManager: Invoked FA.UnregisterAll(\"{P.Name}\")");
+        _registered.Clear();
+    }
+
+    public void MaybeTryInit()
+    {
+        if (!P.Config.WotsitIntegrationEnabled)
+        {
+            return;
+        }
+
+        try
+        {
+            Init();
+        }
+        catch (Exception e)
+        {
+            PluginLog.Warning($"WotsitManager: Failed to initialize: {e}");
+        }
+    }
+
+    private void Init()
+    {
+        ClearWotsit();
+
+        _faRegisterWithSearch = Svc.PluginInterface.GetIpcSubscriber<string, string, string, uint, string>("FA.RegisterWithSearch");
+
+        // TODO: filter out unavailable aetherytes (unless this already does??)
+        foreach (var (rootAetheryte, aethernetShards) in P.DataStore.Aetherytes)
+        {
+            string townName = null;
+            if (AetheryteToTownPlaceName.TryGetValue(rootAetheryte.ID, out var placeId))
+            {
+                townName = Svc.Data.GetExcelSheet<PlaceName>().GetRow(placeId).Name.ToDalamudString().TextValue;
+            }
+            foreach (var aethernetShard in aethernetShards)
+            {
+                if (!P.Config.Hidden.Contains(aethernetShard.ID) && (!aethernetShard.Invisible || InvisibleWhitelist.Contains(aethernetShard.ID)))
+                {
+                    var name = P.Config.Renames.TryGetValue(aethernetShard.ID, out var value) ? value : aethernetShard.Name;
+                    AddWotsitEntry(townName, name, rootAetheryte.ID, aethernetShard.ID);
+                }
+            }
+
+            // Special case for The Firmament
+            if (P.Config.Firmament && rootAetheryte.TerritoryType == 418)
+            {
+                var placeName = Svc.Data.GetExcelSheet<PlaceName>().GetRow(3435).Name.ToDalamudString().TextValue;
+                AddWotsitEntry(townName, placeName, rootAetheryte.ID, TaskAetheryteAethernetTeleport.FirmamentAethernetId);
+            }
+        }
+    }
+
+    private void AddWotsitEntry(string townName, string name, uint aetheryteId, uint aethernetId)
+    {
+        var searchStr = name + (townName != null ? $" - {townName}" : "");
+        var displayName = "Teleport to " + name;
+
+        // TODO: icon ID
+        var id = _faRegisterWithSearch!.InvokeFunc(P.Name, displayName, searchStr, 0);
+        _registered.Add(id, (aetheryteId, aethernetId));
+        PluginLog.Debug($"WotsitManager: Invoked FA.RegisterWithSearch(\"{P.Name}\", \"{displayName}\", \"{searchStr}\", 0) => {id} => ({aetheryteId}, {aethernetId})");
+    }
+}

--- a/Lifestream/IPC/WotsitManager.cs
+++ b/Lifestream/IPC/WotsitManager.cs
@@ -148,7 +148,7 @@ public class WotsitManager : IDisposable
     private void AddWotsitEntry(string townName, string name, uint aetheryteId, uint aethernetId)
     {
         var searchStr = name + (townName != null ? $" - {townName}" : "");
-        var displayName = "Teleport to " + name;
+        var displayName = "Teleport to " + searchStr;
 
         // TODO: icon ID
         var id = _faRegisterWithSearch!.InvokeFunc(P.Name, displayName, searchStr, 0);

--- a/Lifestream/Lifestream.cs
+++ b/Lifestream/Lifestream.cs
@@ -124,6 +124,7 @@ public unsafe class Lifestream : IDalamudPlugin
             {
                 DataStore.BuildWorlds();
                 Config.CharaMap[Player.CID] = Player.NameWithWorld;
+                WotsitManager.MaybeTryInit();
             });
             Svc.Framework.Update += Framework_Update;
             Memory = new();

--- a/Lifestream/Lifestream.cs
+++ b/Lifestream/Lifestream.cs
@@ -67,6 +67,7 @@ public unsafe class Lifestream : IDalamudPlugin
     }
     public VnavmeshManager VnavmeshManager;
     public SplatoonManager SplatoonManager;
+    public WotsitManager WotsitManager;
     public bool DisableHousePathData = false;
     public CharaSelectOverlay CharaSelectOverlay;
 
@@ -134,6 +135,7 @@ public unsafe class Lifestream : IDalamudPlugin
             CustomAethernet = new();
             VnavmeshManager = new();
             SplatoonManager = new();
+            WotsitManager = new();
             IPCProvider = new();
             SingletonServiceManager.Initialize(typeof(Service));
         });
@@ -175,10 +177,18 @@ public unsafe class Lifestream : IDalamudPlugin
             {
                 DuoLog.Error(e.Message);
             }
-            return;
         }
-
-        if(arguments == "stop")
+        else if (arguments == "debug WotsitManager clear")
+        {
+            WotsitManager.TryClearWotsit();
+            Notify.Info("WotsitManager cleared, see logs for details");
+        }
+        else if (arguments == "debug WotsitManager init")
+        {
+            WotsitManager.MaybeTryInit();
+            Notify.Info("WotsitManager reinitialized, see logs for details");
+        }
+        else if(arguments == "stop")
         {
             Notify.Info($"Discarding {TaskManager.NumQueuedTasks + (TaskManager.IsBusy ? 1 : 0)} tasks");
             TaskManager.Abort();
@@ -572,6 +582,7 @@ public unsafe class Lifestream : IDalamudPlugin
 
     public void Dispose()
     {
+        WotsitManager.Dispose();
         Svc.Framework.Update -= Framework_Update;
         Svc.Toasts.ErrorToast -= Toasts_ErrorToast;
         Memory.Dispose();

--- a/Lifestream/Lifestream.cs
+++ b/Lifestream/Lifestream.cs
@@ -7,7 +7,6 @@ using ECommons.Events;
 using ECommons.ExcelServices;
 using ECommons.GameHelpers;
 using ECommons.MathHelpers;
-using ECommons.Reflection;
 using ECommons.SimpleGui;
 using ECommons.Singletons;
 using ECommons.Throttlers;
@@ -155,6 +154,30 @@ public unsafe class Lifestream : IDalamudPlugin
 
     internal void ProcessCommand(string command, string arguments)
     {
+        if (arguments.StartsWith("debug TaskAetheryteAethernetTeleport "))
+        {
+            var args = arguments.Split(" ");
+            if (args.Length == 4 && args[3] == "firmament")
+            {
+                args[3] = TaskAetheryteAethernetTeleport.FirmamentAethernetId.ToString();
+            }
+            if (args.Length != 4 || !uint.TryParse(args[2], out var a) || !uint.TryParse(args[3], out var b))
+            {
+                DuoLog.Error("Invalid arguments");
+                return;
+            }
+
+            try
+            {
+                TaskAetheryteAethernetTeleport.Enqueue(a, b);
+            }
+            catch (Exception e)
+            {
+                DuoLog.Error(e.Message);
+            }
+            return;
+        }
+
         if(arguments == "stop")
         {
             Notify.Info($"Discarding {TaskManager.NumQueuedTasks + (TaskManager.IsBusy ? 1 : 0)} tasks");

--- a/Lifestream/Schedulers/WorldChange.cs
+++ b/Lifestream/Schedulers/WorldChange.cs
@@ -1,4 +1,4 @@
-﻿
+﻿using Dalamud.Game.ClientState.Objects.Types;
 using ECommons.Automation;
 using ECommons.Automation.UIInput;
 using ECommons.GameFunctions;
@@ -218,10 +218,20 @@ internal static unsafe class WorldChange
     }
 
 
-    internal static bool? TargetReachableAetheryte()
+    internal static bool? TargetReachableWorldChangeAetheryte()
+    {
+        return TargetReachableAetheryte(Utils.GetReachableWorldChangeAetheryte);
+    }
+
+    internal static bool? TargetReachableMasterAetheryte()
+    {
+        return TargetReachableAetheryte(Utils.GetReachableMasterAetheryte);
+    }
+
+    internal static bool? TargetReachableAetheryte(Func<bool, IGameObject> aetheryteFunc)
     {
         if(!Player.Available) return false;
-        var a = Utils.GetReachableWorldChangeAetheryte();
+        var a = aetheryteFunc(false);
         if(a != null)
         {
             if(!a.IsTarget() && EzThrottler.Throttle("TargetReachableAetheryte", 200))

--- a/Lifestream/Systems/Legacy/TinyAetheryte.cs
+++ b/Lifestream/Systems/Legacy/TinyAetheryte.cs
@@ -9,8 +9,9 @@ public struct TinyAetheryte : IEquatable<TinyAetheryte>, IAetheryte
     public uint TerritoryType { get; set; }
     public uint ID { get; set; }
     public string Name { get; set; }
-    public uint Group;
-    public bool IsAetheryte;
+    public uint Group { get; set; }
+    public bool IsAetheryte { get; set; }
+    public bool Invisible { get; set; }
     private Aetheryte Ref { get; init; }
 
     public TinyAetheryte(Vector2 position, uint territoryType, uint iD, uint group)
@@ -22,6 +23,7 @@ public struct TinyAetheryte : IEquatable<TinyAetheryte>, IAetheryte
         Group = group;
         Name = Ref.AethernetName.Value.Name.ToDalamudString().TextValue;
         IsAetheryte = Ref.IsAetheryte;
+        Invisible = Ref.Invisible;
     }
 
     public override bool Equals(object obj)

--- a/Lifestream/Tasks/CrossWorld/TaskTPAndChangeWorld.cs
+++ b/Lifestream/Tasks/CrossWorld/TaskTPAndChangeWorld.cs
@@ -27,7 +27,7 @@ internal static class TaskTPAndChangeWorld
                 {
                     P.TaskManager.InsertMulti(
                         new FrameDelayTask(10),
-                        new(WorldChange.TargetReachableAetheryte),
+                        new(WorldChange.TargetReachableWorldChangeAetheryte),
                         new(WorldChange.LockOn),
                         new(WorldChange.EnableAutomove),
                         new(WorldChange.WaitUntilMasterAetheryteExists),

--- a/Lifestream/Tasks/SameWorld/TaskAetheryteAethernetTeleport.cs
+++ b/Lifestream/Tasks/SameWorld/TaskAetheryteAethernetTeleport.cs
@@ -49,12 +49,17 @@ internal static class TaskAetheryteAethernetTeleport
         TaskRemoveAfkStatus.Enqueue();
 
         // Teleport to the root aetheryte unless we're already close to it.
-        if (Svc.ClientState.TerritoryType != territoryId || Utils.GetReachableAetheryte(x => Utils.TryGetTinyAetheryteFromIGameObject(x, out var ae) && ae.HasValue && ae.Value.ID == rootAetheryteId) == null)
+        P.TaskManager.Enqueue(() =>
         {
-            P.TaskManager.Enqueue(() => S.TeleportService.TeleportToAetheryte(rootAetheryteId), "TeleportToRootAetheryte");
-            P.TaskManager.Enqueue(Utils.WaitForScreenFalse);
-            P.TaskManager.Enqueue(Utils.WaitForScreen);
-        }
+            if (Svc.ClientState.TerritoryType != territoryId || Utils.GetReachableAetheryte(x => Utils.TryGetTinyAetheryteFromIGameObject(x, out var ae) && ae.HasValue && ae.Value.ID == rootAetheryteId) == null)
+            {
+                P.TaskManager.InsertMulti(
+                    new(() => S.TeleportService.TeleportToAetheryte(rootAetheryteId), "TeleportToRootAetheryte"),
+                    new(Utils.WaitForScreenFalse),
+                    new(Utils.WaitForScreen)
+                    );
+            }
+        }, "ConditionalTeleportToRootAetheryte");
 
         // Target and ensure we're in range to interact.
         P.TaskManager.EnqueueDelay(10, true);

--- a/Lifestream/Tasks/SameWorld/TaskAetheryteAethernetTeleport.cs
+++ b/Lifestream/Tasks/SameWorld/TaskAetheryteAethernetTeleport.cs
@@ -1,0 +1,101 @@
+﻿using Dalamud.Utility;
+using ECommons.Automation.NeoTaskManager.Tasks;
+using ECommons.GameHelpers;
+using ECommons.Throttlers;
+using Lifestream.Schedulers;
+using Lumina.Excel.Sheets;
+
+namespace Lifestream.Tasks.SameWorld;
+
+internal static class TaskAetheryteAethernetTeleport
+{
+    // Special values for the firmament.
+    internal const uint FirmamentRootAetheryteId = 70;
+    internal const uint FirmamentAethernetId = uint.MaxValue;
+    private const uint FirmamentRootAetheryteTerritoryId = 418;
+    private const string Firmament = "The Firmament";
+
+    internal static void Enqueue(uint rootAetheryteId, uint aethernetId)
+    {
+        if (aethernetId == FirmamentAethernetId)
+        {
+            if (rootAetheryteId != FirmamentRootAetheryteId)
+            {
+                throw new Exception($"Special firmament aethernet {FirmamentAethernetId} must be teleported from root aetheryte {FirmamentRootAetheryteId}");
+            }
+            EnqueueInner(FirmamentRootAetheryteId, FirmamentRootAetheryteTerritoryId, Firmament);
+            return;
+        }
+
+        var rootAetheryte = Svc.Data.GetExcelSheet<Aetheryte>().GetRow(rootAetheryteId);
+        var aethernet = Svc.Data.GetExcelSheet<Aetheryte>().GetRow(aethernetId);
+        if (!rootAetheryte.IsAetheryte)
+        {
+            throw new Exception($"Root aetheryte {rootAetheryteId} is not a full aetheryte");
+        }
+        if (rootAetheryte.AethernetGroup == 0)
+        {
+            throw new Exception($"Root aetheryte {rootAetheryteId} is not part of an aethernet group");
+        }
+        if (aethernet.IsAetheryte)
+        {
+            throw new Exception($"Aethernet {aethernetId} is not an aethernet shard");
+        }
+        if (rootAetheryte.AethernetGroup != aethernet.AethernetGroup)
+        {
+            throw new Exception($"Aethernet {aethernetId} is not in the same aethernet network as root aetheryte {rootAetheryteId}");
+        }
+
+        EnqueueInner(rootAetheryte.RowId, rootAetheryte.Territory.RowId, aethernet.AethernetName.Value.Name.ToDalamudString().TextValue);
+    }
+
+    private static void EnqueueInner(uint rootAetheryteId, uint territoryId, string aethernetName)
+    {
+        if (!Player.Available)
+        {
+            return;
+        }
+
+        TaskRemoveAfkStatus.Enqueue();
+
+        // Teleport to the root aetheryte unless we're already close to it.
+        if (Svc.ClientState.TerritoryType != territoryId || Utils.GetReachableAetheryte(x => Utils.TryGetTinyAetheryteFromIGameObject(x, out var ae) && ae.HasValue && ae.Value.ID == rootAetheryteId) == null)
+        {
+            P.TaskManager.Enqueue(() => S.TeleportService.TeleportToAetheryte(rootAetheryteId), "TeleportToRootAetheryte");
+            P.TaskManager.Enqueue(Utils.WaitForScreenFalse);
+            P.TaskManager.Enqueue(Utils.WaitForScreen);
+        }
+
+        // Target and ensure we're in range to interact.
+        P.TaskManager.EnqueueDelay(10, true);
+        P.TaskManager.Enqueue(WorldChange.TargetReachableMasterAetheryte);
+        P.TaskManager.Enqueue(() =>
+        {
+            if (P.ActiveAetheryte == null)
+            {
+                P.TaskManager.InsertMulti(
+                    new(WorldChange.LockOn),
+                    new(WorldChange.EnableAutomove),
+                    new(WorldChange.WaitUntilMasterAetheryteExists),
+                    new(WorldChange.DisableAutomove),
+                    new FrameDelayTask(10)
+                    );
+            }
+        }, "ConditionalLockonTask");
+        P.TaskManager.Enqueue(WorldChange.InteractWithTargetedAetheryte);
+
+        // If we're going to the firmament, select the firmament option.
+        if (aethernetName == Firmament)
+        {
+            P.TaskManager.Enqueue(() => Utils.TrySelectSpecificEntry(Lang.TravelToFirmament, () => EzThrottler.Throttle("SelectString")),
+                "SelectTravelToFirmament");
+            return;
+        }
+
+        // Otherwise, open the aethernet menu and select the destination.
+        P.TaskManager.Enqueue(WorldChange.SelectAethernet);
+        P.TaskManager.EnqueueDelay(P.Config.SlowTeleport ? P.Config.SlowTeleportThrottle : 0);
+        P.TaskManager.Enqueue(() => WorldChange.TeleportToAethernetDestination(aethernetName),
+            nameof(WorldChange.TeleportToAethernetDestination));
+    }
+}

--- a/Lifestream/Tasks/SameWorld/TaskTryTpToAethernetDestination.cs
+++ b/Lifestream/Tasks/SameWorld/TaskTryTpToAethernetDestination.cs
@@ -42,7 +42,7 @@ internal static class TaskTryTpToAethernetDestination
                 {
                     P.TaskManager.InsertMulti(
                         new FrameDelayTask(10),
-                        new(WorldChange.TargetReachableAetheryte),
+                        new(WorldChange.TargetReachableWorldChangeAetheryte),
                         new(WorldChange.LockOn),
                         new(WorldChange.EnableAutomove),
                         new(WorldChange.WaitUntilMasterAetheryteExists),

--- a/Lifestream/Utils.cs
+++ b/Lifestream/Utils.cs
@@ -244,7 +244,7 @@ internal static unsafe class Utils
             ImGui.BeginTooltip();
             ImGuiEx.Text($"Point: {point:F2}\nLeft-click to finish");
             ImGui.EndTooltip();
-            if(IsKeyPressed(Keys.LButton))
+            if(IsKeyPressed((int)Keys.LButton))
             {
                 isInWorldToScreen = false;
             }
@@ -274,7 +274,7 @@ internal static unsafe class Utils
             ImGui.BeginTooltip();
             ImGuiEx.Text($"Point: {point:F2}\nLeft-click to finish");
             ImGui.EndTooltip();
-            if(IsKeyPressed(Keys.LButton))
+            if(IsKeyPressed((int)Keys.LButton))
             {
                 isInWorldToScreen = false;
             }
@@ -718,8 +718,10 @@ internal static unsafe class Utils
         }
         return distance;
     }
-
+    
     public static bool? WaitForScreen() => IsScreenReady();
+    
+    public static bool? WaitForScreenFalse() => !IsScreenReady();
 
     public static bool ResidentialAetheryteEnumSelector(string name, ref ResidentialAetheryteKind refConfigField)
     {


### PR DESCRIPTION
Adds an integration with the Wotsit plugin via IPC for teleporting to aethernet nodes. The new Task used for this will teleport to the root aetheryte for the given aethernet network first if the player is not nearby it.

For example, if you're in Gridania and you want to TP to The Aftcastle, all you need to do is search for "Aftcastle" in Wotsit and it will teleport you to Limsa and then automatically teleport to The Aftcastle from there.

Every place is searchable by the town name or the specific aethernet name. Most "Other" (aka. "Invisible") aethernet entries are filtered out to avoid adding too much noise to Wotsit with stuff like duplicate "Airship Landings" and gates, but a few useful ones are allowed to show up in Wotsit:
- Prologue Gate (Western Hinterlands)
- Epilogue Gate (Eastern Hinterlands)
- The Ruby Price

Eventually the WotsitManager could be refactored to add other things like entries from the address book and custom aliases for more ergonomic use.

![image](https://github.com/user-attachments/assets/6dcf6d5e-cf9a-47df-a18d-2e4d83f5771d)

This integration can be disabled in the config window (enabled by default).