### PR TITLE
feat: add more actions to Wotsit integration

### DIFF
--- a/Lifestream/Data/Config.cs
+++ b/Lifestream/Data/Config.cs
@@ -78,5 +78,28 @@ public class Config : IEzConfig
     public Dictionary<ulong, string> CharaMap = [];
     public bool UseMount = true;
     public bool WotsitIntegrationEnabled = true;
+    public WotsitIntegrationIncludedItems WotsitIntegrationIncludes = new();
     public bool? AddDtrBar = true;
+
+    public class WotsitIntegrationIncludedItems
+    {
+        public bool WorldSelect = true;
+        public bool PropertyAuto = false;
+        // The built-in Wotsit integration for Teleporter usually ranks higher
+        // than our custom entries, so we disable these by default.
+        public bool PropertyPrivate = false;
+        public bool PropertyFreeCompany = false;
+        public bool PropertyApartment = false;
+        // Inn does routing so it's better than the built-in Wotsit integration.
+        public bool PropertyInn = true;
+        public bool GrandCompany = true;
+        // MarketBoard does routing so it's better than the built-in Wotsit
+        // integration.
+        public bool MarketBoard = true;
+        public bool IslandSanctuary = true;
+
+        public bool AetheryteAethernet = true;
+        public bool AddressBook = true;
+        public bool CustomAlias = true;
+    }
 }

--- a/Lifestream/GUI/UISettings.cs
+++ b/Lifestream/GUI/UISettings.cs
@@ -154,10 +154,67 @@ internal static unsafe class UISettings
         .Section("Wotsit Integration")
         .Widget(() =>
         {
-            if (ImGui.Checkbox("Enable Wotsit Integration for teleporting to Aethernet destinations", ref P.Config.WotsitIntegrationEnabled))
+            var anyChanged = ImGui.Checkbox("Enable Wotsit Integration for teleporting to Aethernet destinations", ref P.Config.WotsitIntegrationEnabled);
+
+            if (P.Config.WotsitIntegrationEnabled)
             {
+                ImGui.Indent();
+                if (ImGui.Checkbox("Include world select window", ref P.Config.WotsitIntegrationIncludes.WorldSelect))
+                {
+                    anyChanged = true;
+                }
+                if (ImGui.Checkbox("Include auto-teleport to property", ref P.Config.WotsitIntegrationIncludes.PropertyAuto))
+                {
+                    anyChanged = true;
+                }
+                if (ImGui.Checkbox("Include teleport to private estate", ref P.Config.WotsitIntegrationIncludes.PropertyPrivate))
+                {
+                    anyChanged = true;
+                }
+                if (ImGui.Checkbox("Include teleport to free company estate", ref P.Config.WotsitIntegrationIncludes.PropertyFreeCompany))
+                {
+                    anyChanged = true;
+                }
+                if (ImGui.Checkbox("Include teleport to apartment", ref P.Config.WotsitIntegrationIncludes.PropertyApartment))
+                {
+                    anyChanged = true;
+                }
+                if (ImGui.Checkbox("Include teleport to inn room", ref P.Config.WotsitIntegrationIncludes.PropertyInn))
+                {
+                    anyChanged = true;
+                }
+                if (ImGui.Checkbox("Include teleport to grand company", ref P.Config.WotsitIntegrationIncludes.GrandCompany))
+                {
+                    anyChanged = true;
+                }
+                if (ImGui.Checkbox("Include teleport to market board", ref P.Config.WotsitIntegrationIncludes.MarketBoard))
+                {
+                    anyChanged = true;
+                }
+                if (ImGui.Checkbox("Include teleport to island sanctuary", ref P.Config.WotsitIntegrationIncludes.IslandSanctuary))
+                {
+                    anyChanged = true;
+                }
+                if (ImGui.Checkbox("Include auto-teleport to aethernet destinations", ref P.Config.WotsitIntegrationIncludes.AetheryteAethernet))
+                {
+                    anyChanged = true;
+                }
+                if (ImGui.Checkbox("Include address book entries", ref P.Config.WotsitIntegrationIncludes.AddressBook))
+                {
+                    anyChanged = true;
+                }
+                if (ImGui.Checkbox("Include custom aliases", ref P.Config.WotsitIntegrationIncludes.CustomAlias))
+                {
+                    anyChanged = true;
+                }
+                ImGui.Unindent();
+            }
+
+            if (anyChanged)
+            {
+                PluginLog.Debug("Wotsit integration settings changed, re-initializing immediately");
                 P.WotsitManager.TryClearWotsit();
-                P.WotsitManager.MaybeTryInit();
+                P.WotsitManager.MaybeTryInit(true);
             }
         })
 

--- a/Lifestream/IPC/WotsitManager.cs
+++ b/Lifestream/IPC/WotsitManager.cs
@@ -1,21 +1,46 @@
 using Dalamud.Plugin.Ipc;
 using Dalamud.Utility;
+using ECommons.Configuration;
+using ECommons.Events;
 using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using Lifestream.Data;
 using Lifestream.Tasks.SameWorld;
+using Lifestream.Tasks.Shortcuts;
 using Lumina.Excel.Sheets;
+using GrandCompany = ECommons.ExcelServices.GrandCompany;
 
 namespace Lifestream.IPC;
 
-public class WotsitManager : IDisposable
+public class WotsitEntry
 {
-    // Map from registered Guid string to (aetheryte ID, aethernet ID).
-    private readonly Dictionary<string, (uint, uint)> _registered = new();
+    public string DisplayName { get; init; }
+    public string SearchString { get; init; }
+    public uint IconId { get; init; }
+    public Delegate Callback { get; init; }
 
-    private readonly ICallGateSubscriber<bool> _faAvailable;
-    private readonly ICallGateSubscriber<string, bool> _faInvoke;
-    private ICallGateSubscriber<string, string, string, uint, string>? _faRegisterWithSearch;
+    public static WotsitEntry AetheryteAethernetTeleport(string townName, string name, uint aetheryteId, uint aethernetId)
+    {
+        var searchStr = name + (townName != null ? $" - {townName}" : "");
+        return new WotsitEntry
+        {
+            DisplayName = "Teleport to " + searchStr,
+            SearchString = searchStr,
+            IconId = 111,
+            Callback = () => TaskAetheryteAethernetTeleport.Enqueue(aetheryteId, aethernetId),
+        };
+    }
 
+    // Callback is intentionally not included in equality checks.
+    public override int GetHashCode() => HashCode.Combine(DisplayName, SearchString, IconId);
+    public override bool Equals(object obj) => obj is WotsitEntry entry && Equals(entry);
+    public bool Equals(WotsitEntry other) => DisplayName == other.DisplayName && SearchString == other.SearchString && IconId == other.IconId;
+
+    public override string ToString() => $"{GetType().Name}(\"{DisplayName}\", \"{SearchString}\", {IconId})";
+}
+
+public static class WotsitEntryGenerator
+{
     private static readonly Dictionary<uint, uint> AetheryteToTownPlaceName = new()
     {
         { 2, 39 },     // Gridania
@@ -43,38 +68,293 @@ public class WotsitManager : IDisposable
         120, // The Ruby Price
     ];
 
+    // These values cannot be read sometimes during a territory change, so we
+    // cache them permanently otherwise they will disappear.
+    private static readonly HashSet<ulong> HasPrivateEstate = [];
+    private static readonly HashSet<ulong> HasFreeCompanyEstate = [];
+    private static readonly HashSet<ulong> HasApartment = [];
+
+    public static IEnumerable<WotsitEntry> Generate()
+    {
+        var includes = P.Config.WotsitIntegrationIncludes;
+
+        foreach (var entry in Generic(includes))
+        {
+            yield return entry;
+        }
+
+        // TODO: eventually residential aethernet could be added too
+        if (includes.AetheryteAethernet)
+        {
+            foreach (var entry in AetheryteAethernetTeleport())
+            {
+                yield return entry;
+            }
+        }
+
+        if (includes.AddressBook)
+        {
+            foreach (var entry in AddressBook())
+            {
+                yield return entry;
+            }
+        }
+
+        if (includes.CustomAlias)
+        {
+            foreach (var entry in CustomAlias())
+            {
+                yield return entry;
+            }
+        }
+    }
+
+    private static IEnumerable<WotsitEntry> Generic(Config.WotsitIntegrationIncludedItems includes)
+    {
+        if (Player.CID != 0 && TaskPropertyShortcut.GetPrivateHouseAetheryteID() != 0)
+        {
+            HasPrivateEstate.Add(Player.CID);
+        }
+        if (Player.CID != 0 && TaskPropertyShortcut.GetFreeCompanyAetheryteID() != 0)
+        {
+            HasFreeCompanyEstate.Add(Player.CID);
+        }
+        if (Player.CID != 0 && TaskPropertyShortcut.GetApartmentAetheryteID().ID != 0)
+        {
+            HasApartment.Add(Player.CID);
+        }
+
+        if (includes.WorldSelect)
+        {
+            yield return new WotsitEntry
+            {
+                DisplayName = "Open world select window",
+                SearchString = "open world select window - open travel window",
+                IconId = 55,
+                Callback = () => S.SelectWorldWindow.IsOpen = true,
+            };
+        }
+        if (includes.PropertyAuto)
+        {
+            yield return new WotsitEntry
+            {
+                DisplayName = "Auto-teleport to property",
+                SearchString = "auto-teleport to property",
+                IconId = 52,
+                Callback = () => TaskPropertyShortcut.Enqueue(TaskPropertyShortcut.PropertyType.Auto),
+            };
+        }
+        if (includes.PropertyPrivate && HasPrivateEstate.Contains(Player.CID)) {
+            yield return new WotsitEntry
+            {
+                DisplayName = "Teleport to your private estate",
+                SearchString = "teleport to your private estate - teleport to home",
+                IconId = 52,
+                Callback = () => TaskPropertyShortcut.Enqueue(TaskPropertyShortcut.PropertyType.Home),
+            };
+        }
+        if (includes.PropertyFreeCompany && HasFreeCompanyEstate.Contains(Player.CID))
+        {
+            yield return new WotsitEntry
+            {
+                DisplayName = "Teleport to your free company estate",
+                SearchString = "teleport to your free company estate - teleport to fc",
+                IconId = 52,
+                Callback = () => TaskPropertyShortcut.Enqueue(TaskPropertyShortcut.PropertyType.FC),
+            };
+        }
+        if (includes.PropertyApartment && HasApartment.Contains(Player.CID)) {
+            yield return new WotsitEntry
+            {
+                DisplayName = "Teleport to your apartment",
+                SearchString = "teleport to your apartment",
+                IconId = 52,
+                Callback = () => TaskPropertyShortcut.Enqueue(TaskPropertyShortcut.PropertyType.Apartment),
+            };
+        }
+        if (includes.PropertyInn)
+        {
+            // TODO: each inn could be a separate entry in the future
+            yield return new WotsitEntry
+            {
+                DisplayName = "Teleport to an inn room",
+                SearchString = "teleport to an inn room",
+                IconId = 88,
+                Callback = () => TaskPropertyShortcut.Enqueue(TaskPropertyShortcut.PropertyType.Inn),
+            };
+        }
+        // TODO: each grand company could be a separate entry in the future
+        if (includes.GrandCompany && Player.GrandCompany != GrandCompany.Unemployed)
+        {
+            var (name, icon) = Player.GrandCompany switch
+            {
+                GrandCompany.Maelstrom => ("Maelstrom", 60313u),
+                GrandCompany.TwinAdder => ("Twin Adder", 60306u),
+                GrandCompany.ImmortalFlames => ("Immortal Flames", 60305u),
+                _ => throw new NotImplementedException(),
+            };
+            yield return new WotsitEntry
+            {
+                DisplayName = "Teleport to your grand company - " + name,
+                SearchString = name + " - teleport to your grand company headquarters - teleport to gc hq",
+                IconId = icon,
+                Callback = () => TaskGCShortcut.Enqueue(Player.GrandCompany),
+            };
+        }
+        if (includes.MarketBoard)
+        {
+            yield return new WotsitEntry
+            {
+                DisplayName = "Teleport to a market board",
+                SearchString = "teleport to a market board - teleport to mb",
+                IconId = 63,
+                Callback = () => TaskMBShortcut.Enqueue(),
+            };
+        }
+        // TODO: the NPCs on the island sanctuary could get their own entries
+        if (includes.IslandSanctuary)
+        {
+            yield return new WotsitEntry
+            {
+                DisplayName = "Teleport to your island sanctuary",
+                SearchString = "teleport to your island sanctuary - teleport to is",
+                IconId = 23,
+                Callback = () => TaskISShortcut.Enqueue(),
+            };
+        }
+    }
+
+    private static IEnumerable<WotsitEntry> AetheryteAethernetTeleport()
+    {
+        // Avoid spoilers by not showing aetherytes that the player hasn't
+        // attuned to.
+        uint[] visibleAetheryteIds = [];
+        if (Player.Available)
+        {
+            unsafe
+            {
+                var visibleAetherytes = Telepo.Instance()->UpdateAetheryteList();
+                if (visibleAetherytes != null)
+                {
+                    visibleAetheryteIds = visibleAetherytes->Select(x => x.AetheryteId).ToArray();
+                }
+            }
+        }
+
+        foreach (var (rootAetheryte, aethernetShards) in P.DataStore.Aetherytes)
+        {
+            if (visibleAetheryteIds.Length > 0 && !visibleAetheryteIds.Contains(rootAetheryte.ID))
+            {
+                PluginLog.Debug($"WotsitEntryGenerator.AetheryteAethernetTeleport: Skipping aetheryte {rootAetheryte.ID} ({rootAetheryte.Name}) because it is not visible");
+                continue;
+            }
+
+            string townName = null;
+            if (AetheryteToTownPlaceName.TryGetValue(rootAetheryte.ID, out var placeId))
+            {
+                townName = Svc.Data.GetExcelSheet<PlaceName>().GetRow(placeId).Name.ToDalamudString().TextValue;
+            }
+            foreach (var aethernetShard in aethernetShards)
+            {
+                if (!P.Config.Hidden.Contains(aethernetShard.ID) && (!aethernetShard.Invisible || InvisibleWhitelist.Contains(aethernetShard.ID)))
+                {
+                    var name = P.Config.Renames.TryGetValue(aethernetShard.ID, out var value) ? value : aethernetShard.Name;
+                    yield return WotsitEntry.AetheryteAethernetTeleport(townName, name, rootAetheryte.ID, aethernetShard.ID);
+                }
+            }
+
+            // Special case for The Firmament
+            if (P.Config.Firmament && rootAetheryte.TerritoryType == 418)
+            {
+                var placeName = Svc.Data.GetExcelSheet<PlaceName>().GetRow(3435).Name.ToDalamudString().TextValue;
+                yield return WotsitEntry.AetheryteAethernetTeleport(townName, placeName, rootAetheryte.ID, TaskAetheryteAethernetTeleport.FirmamentAethernetId);
+            }
+        }
+    }
+
+    private static IEnumerable<WotsitEntry> AddressBook()
+    {
+        foreach (var entry in P.Config.AddressBookFolders.SelectMany(folder => folder.Entries))
+        {
+            var searchStr = entry.Name + (!string.IsNullOrEmpty(entry.Alias) && entry.Alias != entry.Name ? " - " + entry.Alias : "");
+            yield return new WotsitEntry
+            {
+                DisplayName = $"Teleport to address {entry.Name}",
+                SearchString = searchStr,
+                IconId = 52,
+                Callback = entry.GoTo,
+            };
+        }
+    }
+
+    private static IEnumerable<WotsitEntry> CustomAlias()
+    {
+        foreach (var alias in P.Config.CustomAliases.Where(a => a.Enabled && !string.IsNullOrEmpty(a.Alias)))
+        {
+            yield return new WotsitEntry
+            {
+                DisplayName = $"Run alias {alias.Alias}",
+                SearchString = alias.Alias,
+                IconId = 55,
+                Callback = () => alias.Enqueue(),
+            };
+        }
+    }
+}
+
+public class WotsitManager : IDisposable
+{
+    // Map from registered Guid string to the entry.
+    private readonly Dictionary<string, WotsitEntry> _registered = new();
+    private HashSet<WotsitEntry> _lastEntries = new();
+
+    private readonly ICallGateSubscriber<bool> _faAvailable;
+    private readonly ICallGateSubscriber<string, bool> _faInvoke;
+    private ICallGateSubscriber<string, string, string, uint, string>? _faRegisterWithSearch;
+
     public WotsitManager()
     {
         _faAvailable = Svc.PluginInterface.GetIpcSubscriber<bool>("FA.Available");
-        _faAvailable.Subscribe(MaybeTryInit);
+        _faAvailable.Subscribe(OnAvailable);
         _faInvoke = Svc.PluginInterface.GetIpcSubscriber<string, bool>("FA.Invoke");
         _faInvoke.Subscribe(HandleInvoke);
-        MaybeTryInit();
+        // To handle (re)logins (and plugin reloads).
+        ProperOnLogin.RegisterAvailable(OnLogin, true);
+        // To handle logouts and clear all entries.
+        Svc.ClientState.Logout += OnLogout;
+        // To catch new config options, address book entries, aliases, etc.
+        EzConfig.OnSave += ConfigSaved;
+        // To periodically reload generated entries.
+        Svc.ClientState.TerritoryChanged += TerritoryChanged;
     }
 
     public void Dispose()
     {
         ClearWotsit();
-        _faAvailable?.Unsubscribe(MaybeTryInit);
+        _faAvailable?.Unsubscribe(OnAvailable);
         _faInvoke?.Unsubscribe(HandleInvoke);
+        ProperOnLogin.Unregister(OnLogin);
+        Svc.ClientState.Logout -= OnLogout;
+        EzConfig.OnSave -= ConfigSaved;
+        Svc.ClientState.TerritoryChanged -= TerritoryChanged;
         GC.SuppressFinalize(this);
     }
 
     private void HandleInvoke(string id)
     {
-        if (!_registered.TryGetValue(id, out var value))
+        if (!_registered.TryGetValue(id, out var entry))
         {
             return;
         }
-        var (aetheryteId, aethernetId) = value;
-        PluginLog.Debug($"WotsitManager: Received FA.Invoke(\"{id}\") => ({aetheryteId}, {aethernetId})");
+
+        PluginLog.Debug($"WotsitManager: Received FA.Invoke(\"{id}\") => {entry.DisplayName}");
         try
         {
-            TaskAetheryteAethernetTeleport.Enqueue(aetheryteId, aethernetId);
+            entry.Callback.DynamicInvoke();
         }
         catch (Exception e)
         {
-            DuoLog.Error($"Could not teleport to aethernet ({aetheryteId}, {aethernetId}): {e}");
+            DuoLog.Error($"WotsitManager: Could not handle FA.Invoke(\"{id}\") ({entry.DisplayName}): {e}");
         }
     }
 
@@ -92,13 +372,48 @@ public class WotsitManager : IDisposable
 
     private void ClearWotsit()
     {
+        _lastEntries = [];
         var faUnregisterAll = Svc.PluginInterface.GetIpcSubscriber<string, bool>("FA.UnregisterAll");
         faUnregisterAll!.InvokeFunc(P.Name);
         PluginLog.Debug($"WotsitManager: Invoked FA.UnregisterAll(\"{P.Name}\")");
         _registered.Clear();
     }
 
-    public void MaybeTryInit()
+    private void OnAvailable()
+    {
+        PluginLog.Debug("WotsitManager: FA.Available triggered, forcing re-registration");
+        MaybeTryInit(true);
+    }
+
+    private void OnLogin()
+    {
+        PluginLog.Debug("WotsitManager: ProperOnLogin.Available triggered, forcing re-registration");
+        MaybeTryInit(true);
+    }
+
+    private void OnLogout(int type, int code)
+    {
+        PluginLog.Debug("WotsitManager: ClientState.Logout triggered, clearing wotsit");
+        TryClearWotsit();
+    }
+
+    private void ConfigSaved()
+    {
+        if (!Player.Available)
+        {
+            return;
+        }
+        PluginLog.Debug("WotsitManager: Config saved, attempting re-registration");
+        MaybeTryInit(false);
+    }
+
+    private void TerritoryChanged(ushort territory)
+    {
+        PluginLog.Debug($"WotsitManager: Territory changed to {territory}, attempting re-registration");
+        MaybeTryInit(false);
+    }
+
+    public void MaybeTryInit(bool force = false)
     {
         if (!P.Config.WotsitIntegrationEnabled)
         {
@@ -107,7 +422,7 @@ public class WotsitManager : IDisposable
 
         try
         {
-            Init();
+            Init(force);
         }
         catch (Exception e)
         {
@@ -115,64 +430,38 @@ public class WotsitManager : IDisposable
         }
     }
 
-    private unsafe void Init()
+    private void Init(bool force = false)
     {
+        var newEntries = WotsitEntryGenerator.Generate().ToHashSet();
+        if (!force && _lastEntries.Count != 0 && newEntries.SetEquals(_lastEntries))
+        {
+            PluginLog.Debug("WotsitManager: Entries have not changed, skipping re-registration");
+            return;
+        }
+#if DEBUG
+        // Log the actual differences for debugging.
+        if (_lastEntries.Count > 0)
+        {
+            foreach (var added in newEntries.Except(_lastEntries).ToArray())
+            {
+                PluginLog.Debug($"WotsitManager: New entry: {added}");
+            }
+            foreach (var removed in _lastEntries.Except(newEntries).ToArray())
+            {
+                PluginLog.Debug($"WotsitManager: Removed entry: {removed}");
+            }
+        }
+#endif
         ClearWotsit();
+        _lastEntries = newEntries;
 
         _faRegisterWithSearch = Svc.PluginInterface.GetIpcSubscriber<string, string, string, uint, string>("FA.RegisterWithSearch");
 
-        // HACK: Avoid spoilers. Because we never reinitalize WotsitManager, any
-        // new aetherytes will not get added until the next time the plugin is
-        // reloaded.
-        uint[] visibleAetheryteIds = [];
-        if (Player.Available)
+        foreach (var entry in newEntries)
         {
-            var visibleAetherytes = Telepo.Instance()->UpdateAetheryteList();
-            if (visibleAetherytes != null)
-            {
-                visibleAetheryteIds = visibleAetherytes->Select(x => x.AetheryteId).ToArray();
-            }
+            var id = _faRegisterWithSearch!.InvokeFunc(P.Name, entry.DisplayName, $"{P.Name} {entry.SearchString}", entry.IconId);
+            _registered.Add(id, entry);
+            PluginLog.Debug($"WotsitManager: Invoked FA.RegisterWithSearch(\"{P.Name}\", \"{entry.DisplayName}\", \"{entry.SearchString}\", {entry.IconId}) => {id}");
         }
-
-        foreach (var (rootAetheryte, aethernetShards) in P.DataStore.Aetherytes)
-        {
-            if (visibleAetheryteIds.Length > 0 && !visibleAetheryteIds.Contains(rootAetheryte.ID))
-            {
-                PluginLog.Debug($"WotsitManager: Skipping aetheryte {rootAetheryte.ID} ({rootAetheryte.Name}) because it is not visible");
-                continue;
-            }
-
-            string townName = null;
-            if (AetheryteToTownPlaceName.TryGetValue(rootAetheryte.ID, out var placeId))
-            {
-                townName = Svc.Data.GetExcelSheet<PlaceName>().GetRow(placeId).Name.ToDalamudString().TextValue;
-            }
-            foreach (var aethernetShard in aethernetShards)
-            {
-                if (!P.Config.Hidden.Contains(aethernetShard.ID) && (!aethernetShard.Invisible || InvisibleWhitelist.Contains(aethernetShard.ID)))
-                {
-                    var name = P.Config.Renames.TryGetValue(aethernetShard.ID, out var value) ? value : aethernetShard.Name;
-                    AddWotsitEntry(townName, name, rootAetheryte.ID, aethernetShard.ID);
-                }
-            }
-
-            // Special case for The Firmament
-            if (P.Config.Firmament && rootAetheryte.TerritoryType == 418)
-            {
-                var placeName = Svc.Data.GetExcelSheet<PlaceName>().GetRow(3435).Name.ToDalamudString().TextValue;
-                AddWotsitEntry(townName, placeName, rootAetheryte.ID, TaskAetheryteAethernetTeleport.FirmamentAethernetId);
-            }
-        }
-    }
-
-    private void AddWotsitEntry(string townName, string name, uint aetheryteId, uint aethernetId)
-    {
-        var searchStr = name + (townName != null ? $" - {townName}" : "");
-        var displayName = "Teleport to " + searchStr;
-
-        // TODO: icon ID
-        var id = _faRegisterWithSearch!.InvokeFunc(P.Name, displayName, searchStr, 0);
-        _registered.Add(id, (aetheryteId, aethernetId));
-        PluginLog.Debug($"WotsitManager: Invoked FA.RegisterWithSearch(\"{P.Name}\", \"{displayName}\", \"{searchStr}\", 0) => {id} => ({aetheryteId}, {aethernetId})");
     }
 }

--- a/Lifestream/Lifestream.cs
+++ b/Lifestream/Lifestream.cs
@@ -127,7 +127,6 @@ public unsafe class Lifestream : IDalamudPlugin
             {
                 DataStore.BuildWorlds();
                 Config.CharaMap[Player.CID] = Player.NameWithWorld;
-                WotsitManager.MaybeTryInit();
             });
             Svc.Framework.Update += Framework_Update;
             Memory = new();


### PR DESCRIPTION
Adds more destinations to the Wotsit integration (previously only aethernet destinations):
- Open world select window
- Auto-teleport to property (disabled by default)
- Teleport to your private estate (disabled by default)
- Teleport to your free company estate (disabled by default)
- Teleport to your apartment (disabled by default)
- Teleport to an inn room
- Teleport to your grand company
- Teleport to a market board
- Teleport to your island sanctuary
- Address book entries
- Custom alias entries

Adds config options to include/exclude any of the above points (+ aethernet destinations).