### PR TITLE
Progression Overlay to top of the screen

### DIFF
--- a/Lifestream/Data/Config.cs
+++ b/Lifestream/Data/Config.cs
@@ -86,4 +86,5 @@ public class Config : IEzConfig
     public bool LeftAlignButtons = false;
     public LiCommandBehavior LiCommandBehavior = LiCommandBehavior.Return_to_Home_World;
     public bool EnableNotifications = true;
+    public bool ProgressOverlayToTop = false;
 }

--- a/Lifestream/GUI/ProgressOverlay.cs
+++ b/Lifestream/GUI/ProgressOverlay.cs
@@ -54,6 +54,13 @@ internal class ProgressOverlay : Window
         ImGui.PushStyleColor(ImGuiCol.PlotHistogram, col);
         ImGui.ProgressBar(percent, new(ImGui.GetContentRegionAvail().X, 20), overlay);
         ImGui.PopStyleColor();
+        // Toggle ProgressOverlay position logic
+        if (C.ProgressOverlayToTop)
+        {
+            Position = new(0, 0);
+        }
+        else
+        {
         Position = new(0, ImGuiHelpers.MainViewport.Size.Y - ImGui.GetWindowSize().Y);
     }
 

--- a/Lifestream/GUI/UISettings.cs
+++ b/Lifestream/GUI/UISettings.cs
@@ -438,6 +438,7 @@ internal static unsafe class UISettings
             ImGui.Checkbox($"Hide progress bar", ref C.NoProgressBar);
             ImGuiEx.HelpMarker($"Hiding progress bar leaves you with no way to stop Lifestream from executing it's tasks.");
             ImGuiEx.CheckboxInverted($"Don't walk to nearby aetheryte on world change command from greater distance", ref C.WalkToAetheryte);
+            ImGui.Checkbox($"Progress overlay at top of the sreen", ref C.ProgressOverlayToTop);
         })
         .Draw();
     }


### PR DESCRIPTION
Add a checkbox in settings ExpertTab to set ProgressionOverlay at the top of the screen.