### PR TITLE
PaissaUtils only show available houses

### DIFF
--- a/Lifestream/Paissa/PaissaUtils.cs
+++ b/Lifestream/Paissa/PaissaUtils.cs
@@ -13,6 +13,8 @@ public class PaissaUtils
         {
             foreach(var plot in district.OpenPlots)
             {
+                if (plot.LottoPhase != 1) continue;
+
                 // Increment numbers by 1 because PaissaDB has them 0-indexed
                 var wardStr = (plot.WardNumber + 1).ToString();
                 var plotStr = (plot.PlotNumber + 1).ToString();


### PR DESCRIPTION
Currently, any houses will be shown in the PaissaDB import utility, even ones that are not currently available to bid on. This one-liner will take care of that!