### PR TITLE
Added an option to disable the overlay when near a Mini Aetheryte

### DIFF
--- a/Lifestream/Data/Config.cs
+++ b/Lifestream/Data/Config.cs
@@ -21,6 +21,7 @@ public class Config : IEzConfig
     public BasePositionVertical PosVertical = BasePositionVertical.Middle;
     public bool ShowAethernet = true;
     public bool ShowWorldVisit = true;
+    public bool ShowMiniAetheryteOverlay = true;
     public HashSet<uint> Favorites = [];
     public HashSet<uint> Hidden = [];
     public Dictionary<uint, string> Renames = [];

--- a/Lifestream/GUI/Overlay.cs
+++ b/Lifestream/GUI/Overlay.cs
@@ -87,7 +87,7 @@ public class Overlay : Window
         List<Action> actions = [];
         if(S.Data.ResidentialAethernet.IsInResidentialZone())
         {
-            if(C.ShowAethernet)
+            if(C.ShowAethernet && C.ShowMiniAetheryteOverlay)
             {
                 actions.Add(() => DrawResidentialAethernet(false));
                 actions.Add(() => DrawResidentialAethernet(true));
@@ -390,7 +390,7 @@ public class Overlay : Window
         }
         else if(canUse == AetheryteUseState.Residential || canUse == AetheryteUseState.Custom)
         {
-            ret = C.ShowAethernet;
+            ret = C.ShowAethernet && (canUse != AetheryteUseState.Residential || C.ShowMiniAetheryteOverlay);
         }
         if(canUse == AetheryteUseState.None)
         {

--- a/Lifestream/GUI/UISettings.cs
+++ b/Lifestream/GUI/UISettings.cs
@@ -319,6 +319,7 @@ internal static unsafe class UISettings
                 ImGui.Checkbox($"Display Aethernet menu", ref C.ShowAethernet);
                 ImGui.Checkbox($"Display World Visit menu", ref C.ShowWorldVisit);
                 ImGui.Checkbox($"Display Housing Ward buttons", ref C.ShowWards);
+                ImGui.Checkbox($"Display overlay near Miniature Aetherytes", ref C.ShowMiniAetheryteOverlay);
 
                 UtilsUI.NextSection();
 

--- a/Lifestream/Systems/Residential/ResidentialAethernet.cs
+++ b/Lifestream/Systems/Residential/ResidentialAethernet.cs
@@ -92,7 +92,7 @@ public sealed class ResidentialAethernet : IDisposable
             var aetheryte = GetFromIGameObject(a);
             if(aetheryte != null)
             {
-                if(ActiveAetheryte == null)
+                if(ActiveAetheryte == null && C.ShowMiniAetheryteOverlay)
                 {
                     S.Gui.Overlay.IsOpen = true;
                 }


### PR DESCRIPTION
This pull request will add another checkbox inside of the overlay settings, "Display overlay near Miniature Aetherytes".
With that it would be possible to have the overlay not show up when being near a Mini Aetheryte.

It's mostly a personal problem I want to solve with this, but I thought some other people might find it handy as well. Because I have a Mini Aetheryte right next to my house and when I walk around my plot, bell or marketboard it will always show the overlay and then hide it again.