### PR TITLE
feat: add additional checks in `AethernetShards` for KR client

### DIFF
--- a/Lifestream/Utils.cs
+++ b/Lifestream/Utils.cs
@@ -950,7 +950,12 @@ internal static unsafe partial class Utils
                 {
                     //2000151	Aethernet shard	0	Aethernet shards	0	1	1	0	0
                     //2014665	aetheryte shard	0	aetheryte shards	0	1	1	0	0
-                    if(x.Singular.GetText().EqualsAny(EObjName.Get(2000151).Singular.GetText(), EObjName.Get(2014665).Singular.GetText()))
+                    if(x.Singular.GetText().EqualsAny(
+                        EObjName.Get(2000151).Singular.GetText(),
+                        EObjName.Get(2014665).Singular.GetText(),
+                        EObjName.Get(2014664).Singular.GetText(),        // KR: Occult Aetheryte in Occult Crescent
+                        EObjName.Get(2003395).Singular.GetText()         // KR: Aethernet Shard in housing area
+                    ))
                     {
                         ret.Add(x.RowId);
                     }
@@ -961,7 +966,12 @@ internal static unsafe partial class Utils
                     {
                         //2000151	Aethernet shard	0	Aethernet shards	0	1	1	0	0
                         //2014665	aetheryte shard	0	aetheryte shards	0	1	1	0	0
-                        if(x.Singular.GetText().EqualsAny(EObjName.Get(2000151, ClientLanguage.English).Singular.GetText(), EObjName.Get(2014665, ClientLanguage.English).Singular.GetText()))
+                        if(x.Singular.GetText().EqualsAny(
+                            EObjName.Get(2000151, ClientLanguage.English).Singular.GetText(),
+                            EObjName.Get(2014665, ClientLanguage.English).Singular.GetText(),
+                            EObjName.Get(2014664, ClientLanguage.English).Singular.GetText(),        // KR: Occult Aetheryte in Occult Crescent
+                            EObjName.Get(2003395, ClientLanguage.English).Singular.GetText()         // KR: Aethernet Shard in housing area
+                        ))
                         {
                             ret.Add(x.RowId);
                         }


### PR DESCRIPTION
KR client has different `Singular` text for `Occult Aetheryte` and `Aethernet Shard`.
This change should not affect EN client.

## Occult Crescent

EObjName RowId `2014665` entry is `Aetheryte Shard`, whose Korean `Singular` representation is `간이 마도 통로`.
`2014664` is `Occult Aetheryte` in EN client (`마도 통로` in KR client) and it is not listed up in original `AethernetShards` array.

## Housing area

`2000151` is an aethernet shard in a city and `2003395` is an aethernet shard in Mist.
In KR client, the former is different from aethernet shards in housing area. (`도시 내 에테라이트` for former, `간이 에테라이트` for latter)
