### PR TITLE
Fix Aethernet Shard to Address bug

### DIFF
--- a/Lifestream/Tasks/CrossDC/TaskTpAndGoToWard.cs
+++ b/Lifestream/Tasks/CrossDC/TaskTpAndGoToWard.cs
@@ -45,9 +45,25 @@ public static unsafe class TaskTpAndGoToWard
         P.TaskManager.Enqueue(() =>
         {
             P.UpdateAetherytes();
-            if(P.Territory != residentialArtheryte.GetTerritory() || (!Utils.ApproachConditionIsMet() && P.ActiveAetheryte?.IsAetheryte != true))
+            if(P.Territory != residentialArtheryte.GetTerritory())
             {
                 TaskTpToResidentialAetheryte.Insert(residentialArtheryte);
+            }
+            else if(P.ActiveAetheryte?.IsAetheryte != true)
+            {
+                if(Utils.GetReachableAetheryte(x => x.IsAetheryte()) != null && S.Data.DataStore.Aetherytes.Keys.TryGetFirst(a => a.ID == (uint)residentialArtheryte, out var rootAetheryte))
+                {
+                    P.TaskManager.InsertStack(() =>
+                    {
+                        TaskAethernetTeleport.Enqueue(rootAetheryte);
+                        P.TaskManager.Enqueue(Utils.WaitForScreenFalse);
+                        P.TaskManager.Enqueue(Utils.WaitForScreen);
+                    });
+                }
+                else
+                {
+                    TaskTpToResidentialAetheryte.Insert(residentialArtheryte);
+                }
             }
         }, "TaskTpToResidentialAetheryteIfNeeded");
         P.TaskManager.Enqueue(() => Utils.GetReachableAetheryte(x => x.ObjectKind == ObjectKind.Aetheryte) != null, "WaitUntilReachableAetheryteExists");


### PR DESCRIPTION
There is currently a bug where if we're in the same territory as the main aetheryte for an address' residence and we try to move to that address the character will try to interact with the Aethernet Shard and hang

For example if we're in Zodiark's Limsa Lower Decks next to an aethernet shard and we try to go to an address in Zodiark's Mist residential area, it will fail.

Reproduction steps:
```
/li Hawk
/li Mist w1 p1
```

I made it use the aethernet shard to get to the main aetheryte and then proceed, but feel free to change it if you'd prefer to just have the character TP to keep the behaviour consistent with other aetherytes in the same city but not the same territory (in the example provided it would be Zodiark's Limsa Upper Decks).
