### PR TITLE
fix: add Phantom Village to Wotsit

### DIFF
--- a/Lifestream/IPC/Wotsit/WotsitEntryGenerator.cs
+++ b/Lifestream/IPC/Wotsit/WotsitEntryGenerator.cs
@@ -36,6 +36,7 @@ public static class WotsitEntryGenerator
         91,  // Prologue Gate (Western Hinterlands)
         92,  // Epilogue Gate (Eastern Hinterlands)
         120, // The Ruby Price
+        239, // Phantom Village
     ];
 
     // These values cannot be read sometimes during a territory change, so we


### PR DESCRIPTION
The Phantom Village is a invisible destination, so it needs to be added to the whitelist.